### PR TITLE
Add cancel action to contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
           <div class="card compact-form hidden" id="contact-form-card">
             <div class="form-header">
               <h3 id="form-title">Add Contact</h3>
-              <button type="button" id="btn-cancel-contact" class="chip">Cancel</button>
+              <button type="button" class="chip btn-cancel-contact">Cancel</button>
             </div>
             <form id="contact-form" onsubmit="event.preventDefault();return false;">
               <input type="hidden" id="contact-id" />
@@ -178,6 +178,7 @@
                 </div>
                 <div class="col-12 row" style="justify-content:flex-start">
                   <button class="chip strong" type="submit" id="btn-save-contact">Save</button>
+                  <button type="button" class="chip btn-cancel-contact">Cancel</button>
                   <button type="button" id="btn-reset" class="chip">Reset</button>
                   <span class="muted" style="margin-left:auto">Tip: set Frequency to Custom for exact days.</span>
                 </div>
@@ -682,7 +683,9 @@
 
       $("#contact-form").addEventListener("submit", saveContactFromForm);
       $("#btn-reset").addEventListener("click", clearContactForm);
-      $("#btn-cancel-contact").addEventListener("click", ()=> hideContactForm());
+      document.querySelectorAll(".btn-cancel-contact").forEach(btn=>{
+        btn.addEventListener("click", ()=> hideContactForm());
+      });
       $("#frequency").addEventListener("change", ()=>{
         const f=$("#frequency").value;
         $("#freqDays").value = (defaultDaysMap[f]||Number($("#freqDays").value||30));


### PR DESCRIPTION
## Summary
- add a cancel button alongside the save action in the contact form
- wire all cancel buttons to hide the contact form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1ded80ad08326b8868ae41d25fd5e