### PR TITLE
Remove duplicate cancel button from contact form header

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,6 @@
           <div class="card compact-form hidden" id="contact-form-card">
             <div class="form-header">
               <h3 id="form-title">Add Contact</h3>
-              <button type="button" class="chip btn-cancel-contact">Cancel</button>
             </div>
             <form id="contact-form" onsubmit="event.preventDefault();return false;">
               <input type="hidden" id="contact-id" />


### PR DESCRIPTION
## Summary
- remove the redundant cancel button from the contact form header so only the footer control remains

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f26857947883269c3dd295e9344859